### PR TITLE
Update: Minimize disconnection from server error

### DIFF
--- a/Client/Scenes/GameScene/Player.gd
+++ b/Client/Scenes/GameScene/Player.gd
@@ -62,7 +62,7 @@ func _physics_process(delta) -> void:
 
 	if Input.is_action_pressed("right_D") :
 		movement_direction.x = 1
-
+	Server.maintainConnection()
 	movement_direction = movement_direction.normalized();
 	position += movement_direction * delta
 
@@ -85,6 +85,7 @@ func _process(delta):
 		put_barrels()
 	if Input.is_action_pressed("Pause_game"):
 		pause_game()
+	Server.maintainConnection()
 
 func grenade_update(num):
 	num_grenade = num

--- a/Client/Scenes/GameScene/WeaponManager.gd
+++ b/Client/Scenes/GameScene/WeaponManager.gd
@@ -51,6 +51,7 @@ func _unhandled_input(event):
 		change_next_weapon()
 	if event.is_action_pressed("previous_weapon"):
 		change_previous_weapon()
+	Server.maintainConnection()
 
 # functions to add ammo when the players take the ammo
 func add_ammo_curr_weapon(ammo):

--- a/Client/Scenes/MainScenesV2/AccountSetting.gd
+++ b/Client/Scenes/MainScenesV2/AccountSetting.gd
@@ -8,6 +8,7 @@ onready var userNameErrLbl = $MarginContainer/VBoxContainer/VBoxContainer2/errLa
 var preDisconnectScene = preload("res://Scenes/MainScenesV2/Disconnect.tscn")
 
 func _ready():
+	Server.maintainConnection()
 	usernameInpt.text = Global.username
 	emailInpt.text = Global.email
 	$usernameLabel.text = Global.username
@@ -52,7 +53,6 @@ func auth_user_request(result, response_code, headers, body):
 
 func _on_changePasswordBtn_pressed():
 	get_tree().change_scene("res://Scenes/MainScenesV2/ChangePassword.tscn")
-
 
 func _on_saveChangesBtn_pressed():
 	if usernameInpt.text != Global.username: # There is a change in username

--- a/Client/Scenes/MainScenesV2/ChangePassword.gd
+++ b/Client/Scenes/MainScenesV2/ChangePassword.gd
@@ -8,6 +8,7 @@ onready var cfmPasswordInpt = $MarginContainer/VBoxContainer/VBoxContainer2/cfmP
 onready var errLabel = $MarginContainer/VBoxContainer/VBoxContainer2/errLabel
 
 func _ready():
+	Server.maintainConnection()
 	$usernameLabel.text = Global.username
 	Server.network.connect("server_disconnected", self, "_on_server_disconnect")
 	Server.network.connect("connection_failed", self, "_on_connection_failed")

--- a/Client/Scenes/MainScenesV2/ControlSetting.gd
+++ b/Client/Scenes/MainScenesV2/ControlSetting.gd
@@ -18,6 +18,7 @@ onready var prevWpnBtn = $VBoxContainer/ScrollContainer/VBoxContainer/prevWeapon
 func _ready():
 	Server.network.connect("server_disconnected", self, "_on_server_disconnect")
 	Server.network.connect("connection_failed", self, "_on_connection_failed")
+	Server.maintainConnection()
 	$usernameLabel.text = Global.username	
 	ControlScript.setKeyDict(Global.settings["control"])
 	upBtn.text = OS.get_scancode_string(controls["up_W"])

--- a/Client/Scenes/MainScenesV2/GameplaySetting.gd
+++ b/Client/Scenes/MainScenesV2/GameplaySetting.gd
@@ -5,6 +5,7 @@ var preDisconnectScene = preload("res://Scenes/MainScenesV2/Disconnect.tscn")
 
 func _ready():
 	$usernameLabel.text = Global.username
+	Server.maintainConnection()
 	Server.network.connect("server_disconnected", self, "_on_server_disconnect")
 	Server.network.connect("connection_failed", self, "_on_connection_failed")
 

--- a/Client/Scenes/MainScenesV2/Inventory.gd
+++ b/Client/Scenes/MainScenesV2/Inventory.gd
@@ -59,6 +59,7 @@ func _ready():
 	creditLbl.text = str(invData["Credit"])
 	Server.network.connect("server_disconnected", self, "_on_server_disconnect")
 	Server.network.connect("connection_failed", self, "_on_connection_failed")
+	Server.maintainConnection()
 
 func _on_server_disconnect():
 	var disconnectScene = preDisconnectScene.instance()

--- a/Client/Scenes/MainScenesV2/Lobby.gd
+++ b/Client/Scenes/MainScenesV2/Lobby.gd
@@ -28,6 +28,7 @@ func _ready():
 		$lobbyContainer/lobbyScroll/roomContainer.add_child(button)
 	Server.network.connect("server_disconnected", self, "_on_server_disconnect")
 	Server.network.connect("connection_failed", self, "_on_connection_failed")
+	Server.maintainConnection()
 
 
 func _on_connection_failed():

--- a/Client/Scenes/MainScenesV2/MainMenu.gd
+++ b/Client/Scenes/MainScenesV2/MainMenu.gd
@@ -24,6 +24,7 @@ func _ready():
 
 	Server.network.connect("server_disconnected", self, "_on_server_disconnect")
 	Server.network.connect("connection_failed", self, "_on_connection_failed")
+	Server.maintainConnection()
 
 func _on_server_disconnect():
 	var disconnectScene = preDisconnectScene.instance()

--- a/Client/Scenes/MainScenesV2/ModeSelection.gd
+++ b/Client/Scenes/MainScenesV2/ModeSelection.gd
@@ -8,6 +8,7 @@ func _ready():
 	$usernameLabel.text = Global.username
 	Server.network.connect("server_disconnected", self, "_on_server_disconnect")
 	Server.network.connect("connection_failed", self, "_on_connection_failed")
+	Server.maintainConnection()
 
 func _on_server_disconnect():
 	var disconnectScene = preDisconnectScene.instance()

--- a/Client/Scenes/MainScenesV2/MultiPlayerMode.gd
+++ b/Client/Scenes/MainScenesV2/MultiPlayerMode.gd
@@ -21,6 +21,7 @@ func _ready():
 	if Global.isLeader:
 		$startButton.visible = true
 	Server.network.connect("server_disconnected", self, "_on_server_disconnect")
+	Server.maintainConnection()
 
 func _on_server_disconnect():
 	var disconnectScene = preDisconnectScene.instance()

--- a/Client/Scenes/MainScenesV2/Setting.gd
+++ b/Client/Scenes/MainScenesV2/Setting.gd
@@ -8,6 +8,7 @@ func _ready():
 	$usernameLabel.text = Global.username
 	Server.network.connect("server_disconnected", self, "_on_server_disconnect")
 	Server.network.connect("connection_failed", self, "_on_connection_failed")
+	Server.maintainConnection()
 
 func _on_server_disconnect():
 	var disconnectScene = preDisconnectScene.instance()

--- a/Client/Scenes/MainScenesV2/Shop.gd
+++ b/Client/Scenes/MainScenesV2/Shop.gd
@@ -47,6 +47,7 @@ func _ready():
 	$usernameLabel.text = Global.username
 	Server.network.connect("server_disconnected", self, "_on_server_disconnect")
 	Server.network.connect("connection_failed", self, "_on_connection_failed")
+	Server.maintainConnection()
 
 func _on_server_disconnect():
 	var disconnectScene = preDisconnectScene.instance()

--- a/Client/Scenes/MainScenesV2/SinglePlayerMode.gd
+++ b/Client/Scenes/MainScenesV2/SinglePlayerMode.gd
@@ -18,6 +18,7 @@ func _ready():
 	highscoreValLbl.bbcode_text = "[center][u]" + str(Global.highscore) + "[/u][/center]"
 	Server.network.connect("server_disconnected", self, "_on_server_disconnect")
 	Server.network.connect("connection_failed", self, "_on_connection_failed")
+	Server.maintainConnection()
 
 func _on_server_disconnect():
 	var disconnectScene = preDisconnectScene.instance()

--- a/Client/Scenes/MainScenesV2/SoundSetting.gd
+++ b/Client/Scenes/MainScenesV2/SoundSetting.gd
@@ -24,6 +24,7 @@ func _ready():
 	$usernameLabel.text = Global.username
 	Server.network.connect("server_disconnected", self, "_on_server_disconnect")
 	Server.network.connect("connection_failed", self, "_on_connection_failed")
+	Server.maintainConnection()
 
 
 func _on_server_disconnect():

--- a/Client/Scenes/Multiplayer/(Multi)Player.gd
+++ b/Client/Scenes/Multiplayer/(Multi)Player.gd
@@ -65,6 +65,8 @@ func _physics_process(delta):
 		player_label.rect_position = Vector2(position.x - 10, position.y - 66)
 		var x_input = int(Input.is_action_pressed("right_D")) - int(Input.is_action_pressed("left_A"))
 		var y_input = int(Input.is_action_pressed("down_S")) - int(Input.is_action_pressed("up_W"))
+		
+		Server.maintainConnection()
 			
 		motion = Vector2(x_input, y_input).normalized()
 			
@@ -98,6 +100,7 @@ func _unhandled_input(event):
 			rpc_id(1, "put_barrel", num_barrel - 1, Global.uuid)
 		if event.is_action_pressed("Pause_game"):
 			show_pause_menu()
+		Server.maintainConnection()
 			
 func _process(delta):
 	get_node("ItemGUI/GrenadePanel/GreandeLabel").set_text(str(invData["Grenade"]["Ammo"]))
@@ -166,7 +169,6 @@ remote func barrel_update(num, uuid):
 	num_barrel = num
 	invData["Barrel"]["Ammo"] = num_barrel
 	invCollection.update("" + uuid, {"Barrel" : invData["Barrel"]})
-
 
 func zombie_attack(zombie_dmg):
 	$HealthBar.health_deducted(zombie_dmg)

--- a/Client/Scenes/Multiplayer/(Multi)WeaponManager.gd
+++ b/Client/Scenes/Multiplayer/(Multi)WeaponManager.gd
@@ -54,6 +54,7 @@ func _unhandled_input(event):
 			rpc_id(1,"change_next")
 		if event.is_action_pressed("previous_weapon"):
 			rpc_id(1,"change_previous")
+		Server.maintainConnection()
 
 remotesync func spawn_bullet():
 	currWeapon.shoot()

--- a/Client/Scenes/Singletons/Server.gd
+++ b/Client/Scenes/Singletons/Server.gd
@@ -176,3 +176,10 @@ func end_game():
 # on the server. Does not matter who does it first
 func clearRoom():
 	rpc_id(1, "clearRoom", Global.roomName)
+
+# Maintain connection to server
+func maintainConnection():
+	rpc_id(1, "maintainConnection")
+
+remote func maintainPlayerConnection():
+	pass

--- a/Server/Scenes/Singletons/Server.gd
+++ b/Server/Scenes/Singletons/Server.gd
@@ -1,8 +1,8 @@
 extends Node
 
 const port = 4444
-#var network = WebSocketServer.new()
-var network = NetworkedMultiplayerENet.new()
+var network = WebSocketServer.new()
+#var network = NetworkedMultiplayerENet.new()
 onready var root_node = get_tree().get_root()
 var rmname
 
@@ -10,13 +10,13 @@ func _ready():
 	start_server()
 	
 func _process(_delta):
-	pass
-#	if network.is_listening():
-#		network.poll()
+#	pass
+	if network.is_listening():
+		network.poll()
 
 func start_server():
-#	network.listen(port, PoolStringArray(), true);
-	network.create_server(port, 100)
+	network.listen(port, PoolStringArray(), true);
+#	network.create_server(port, 100)
 	get_tree().set_network_peer(network)
 	network.connect("peer_connected", self, "_peer_connected")
 	network.connect("peer_disconnected", self, "_peer_disconnected")
@@ -195,3 +195,7 @@ remote func clearRoom(roomName):
 remote func exit_midway(roomname):
 	Global.room.erase(roomname)
 	Global.activeRoom.erase(roomname)
+
+remote func maintainConnection():
+	var playerId = get_tree().get_rpc_sender_id()
+	rpc_id(playerId, "maintainPlayerConnection")


### PR DESCRIPTION
Problem was that the server and client connection was independent of what the user is doing on the frontend. A regular req between client and server is needed.

Added two new code to Server.gd (Client):

func maintainConnection():
	rpc_id(1, "maintainConnection")

remote func maintainPlayerConnection():
	pass

And 

remote func maintainConnection():
	var playerId = get_tree().get_rpc_sender_id()
	rpc_id(playerId, "maintainPlayerConnection")


maintainConnection() is called whenever users do an action such as loading a new page or doing actions (movement/shooting) in game. This would send a req to the server which in turn send a req back to client. Therefore, maintaining connections between Client and Server.
